### PR TITLE
Turn off mipmap on main graph texture

### DIFF
--- a/GCMonitor.cs
+++ b/GCMonitor.cs
@@ -55,7 +55,7 @@ namespace GCMonitor
 
         private bool hiddenUI = false;
 
-        readonly Texture2D memoryTexture = new Texture2D(width, height);
+        readonly Texture2D memoryTexture = new Texture2D(width, height, TextureFormat.ARGB32, false);
         float ratio;
 
         private int _timeScale = 1;


### PR DESCRIPTION
To fix the graph going blurry at reduced texture resolution settings.

Also, there are no project or solution files.  I've had a go at setting it up in VS2015 but I've been unable to actually build it.  It appears there are various other bits missing (Extensions and UICollapsible).  I'll take a bit more of a look later.